### PR TITLE
docs: fix name of a kwarg in the docstring

### DIFF
--- a/src/tvdiff.jl
+++ b/src/tvdiff.jl
@@ -64,7 +64,7 @@
     derivatives, whereas the absolute values tends to make them more blocky.
   - `cg_tol::Real`:
     Relative tolerance used in conjugate gradient method. Default is `1e-6`.
-  - `cgmaxit::Int`:
+  - `cg_maxiter::Int`:
     Maximum number of iterations to use in conjugate gradient optimisation.
     Default is `100`.
   - `show_diagn::Bool`:


### PR DESCRIPTION
`cgmaxit `  -> `cg_maxiter`